### PR TITLE
solutions optimization

### DIFF
--- a/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
+++ b/patches/tModLoader/Terraria/IO/WorldFile.cs.patch
@@ -73,6 +73,14 @@
  				if (num3 != 0)
  					WorldGen.loadFailed = true;
  				else
+@@ -557,6 +_,7 @@
+ 			return;
+ 		}
+ 
++		TileFrameCache.InitializeTileFramer();
+ 		if (WorldFile.OnWorldLoad != null)
+ 			WorldFile.OnWorldLoad();
+ 	}
 @@ -652,6 +_,9 @@
  		if (Main.worldPathName == null)
  			return;

--- a/patches/tModLoader/Terraria/Main.cs.patch
+++ b/patches/tModLoader/Terraria/Main.cs.patch
@@ -1919,9 +1919,19 @@
  			CinematicManager.Instance.Update(gameTime);
  			if (netMode == 2) {
  				for (int i = 0; i < 256; i++) {
-@@ -13526,6 +_,7 @@
+@@ -13437,6 +_,7 @@
+ 	protected void DoUpdate(ref GameTime gameTime)
+ 	{
+ 		gameTimeCache = gameTime;
++
+ 		if (showSplash) {
+ 			UpdateAudio();
+ 			GlobalTimeWrappedHourly = (float)(gameTime.TotalGameTime.TotalSeconds % 3600.0);
+@@ -13525,7 +_,9 @@
+ 				updatesCountedForFPS = 0;
  			}
  		}
++		TileFrameCache.ResolveFrame();
  
 +		LocalizationLoader.Update();
  		DoUpdate_AutoSave();

--- a/patches/tModLoader/Terraria/ModLoader/Conversion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Conversion.cs
@@ -4,7 +4,7 @@ namespace Terraria.ModLoader;
 
 public sealed class Conversion
 {
-	public record struct BlockConversion(int From, int To, bool IsTile)
+	public record class BlockConversion(int From, int To, bool IsTile)
 	{
 		public delegate ConversionRunCodeValues PreConversionDelegate(Tile tile, int i, int j, ConversionHandler.ConversionSettings settings);
 		public delegate void OnConversionDelegate(Tile tile, int oldTileType, int i, int j, ConversionHandler.ConversionSettings settings);

--- a/patches/tModLoader/Terraria/ModLoader/Conversion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Conversion.cs
@@ -4,7 +4,7 @@ namespace Terraria.ModLoader;
 
 public sealed class Conversion
 {
-	public record class BlockConversion(int From, int To, bool IsTile)
+	public record struct BlockConversion(int From, int To, bool IsTile)
 	{
 		public delegate ConversionRunCodeValues PreConversionDelegate(Tile tile, int i, int j, ConversionHandler.ConversionSettings settings);
 		public delegate void OnConversionDelegate(Tile tile, int oldTileType, int i, int j, ConversionHandler.ConversionSettings settings);

--- a/patches/tModLoader/Terraria/ModLoader/Conversion.cs
+++ b/patches/tModLoader/Terraria/ModLoader/Conversion.cs
@@ -4,13 +4,13 @@ namespace Terraria.ModLoader;
 
 public sealed class Conversion
 {
-	public sealed record class BlockConversion(int From, int To, bool IsTile)
+	public record struct BlockConversion(int From, int To, bool IsTile)
 	{
 		public delegate ConversionRunCodeValues PreConversionDelegate(Tile tile, int i, int j, ConversionHandler.ConversionSettings settings);
 		public delegate void OnConversionDelegate(Tile tile, int oldTileType, int i, int j, ConversionHandler.ConversionSettings settings);
 
-		public LinkedList<PreConversionDelegate> PreConversionHooks;
-		public OnConversionDelegate OnConversionHook;
+		public LinkedList<PreConversionDelegate> PreConversionHooks = new();
+		public LinkedList<OnConversionDelegate> OnConversionHook = new();
 
 		public BlockConversion PreConversion(PreConversionDelegate preConversionHook)
 		{
@@ -21,7 +21,8 @@ public sealed class Conversion
 
 		public BlockConversion OnConversion(OnConversionDelegate onConversionHook)
 		{
-			OnConversionHook += onConversionHook;
+			OnConversionHook ??= new();
+			OnConversionHook.AddLast(onConversionHook);
 			return this;
 		}
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
@@ -58,14 +58,16 @@ public static class TileFrameCache
 	{
 		if (!TileFramer[x, y][0]) {
 			TileFramer[x, y][0] = true;
-			TileQueue.AddFirst(new Tuple<int, int, bool>(x, y, resetFrame));
+			Tuple<int, int, bool> data = new(x, y, resetFrame);
+			TileQueue.AddFirst(data);
 		}
 	}
 	public static void QueueWallFrame(int x, int y, bool resetFrame = false)
 	{
 		if (!TileFramer[x, y][1]) {
 			TileFramer[x, y][1] = true;
-			WallQueue.AddFirst(new Tuple<int, int, bool>(x, y, resetFrame));
+			Tuple<int, int, bool> data = new(x, y, resetFrame);
+			WallQueue.AddFirst(data);
 		}
 	}
 
@@ -78,13 +80,13 @@ public static class TileFrameCache
 			WorldGen.TileFrame(item.Item1, item.Item2, item.Item3);
 
 		}
-		TileQueue.Clear();
+		TileQueue = new();
 		for (LinkedListNode<Tuple<int, int, bool>> node = WallQueue.First; node != null; node = node.Next) {
 			item = node.Value;
 			TileFramer[item.Item1, item.Item2][1] = false;
 			Framing.WallFrame(item.Item1, item.Item2, item.Item3);
 		}
-		WallQueue.Clear();
+		WallQueue = new();
 	}
 }
 public sealed class ConversionHandler

--- a/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
@@ -16,8 +16,8 @@ public static class TileFrameCache
 {
 	internal static BitsByte[,] TileFramer;
 
-	internal static LinkedList<Tuple<int, int, bool>> TileQueue = new();
-	internal static LinkedList<Tuple<int, int, bool>> WallQueue = new();
+	internal static LinkedList<Tuple<int, int>> TileQueue = new();
+	internal static LinkedList<Tuple<int, int>> WallQueue = new();
 
 	internal static void InitializeTileFramer()
 	{
@@ -58,33 +58,42 @@ public static class TileFrameCache
 	{
 		if (!TileFramer[x, y][0]) {
 			TileFramer[x, y][0] = true;
-			Tuple<int, int, bool> data = new(x, y, resetFrame);
+			Tuple<int, int> data = new(x, y);
 			TileQueue.AddFirst(data);
 		}
+		if (resetFrame)
+			TileFramer[x, y][1] = true;
 	}
 	public static void QueueWallFrame(int x, int y, bool resetFrame = false)
 	{
-		if (!TileFramer[x, y][1]) {
-			TileFramer[x, y][1] = true;
-			Tuple<int, int, bool> data = new(x, y, resetFrame);
+		if (!TileFramer[x, y][2]) {
+			TileFramer[x, y][2] = true;
+			Tuple<int, int> data = new(x, y);
 			WallQueue.AddFirst(data);
 		}
+		if (resetFrame)
+			TileFramer[x, y][3] = true;
 	}
 
 	public static void ResolveFrame()
 	{
-		Tuple<int, int, bool> item;
-		for (LinkedListNode<Tuple<int, int, bool>> node = TileQueue.First; node != null; node = node.Next) {
+		Tuple<int, int> item;
+		BitsByte data;
+		for (LinkedListNode<Tuple<int, int>> node = TileQueue.First; node != null; node = node.Next) {
 			item = node.Value;
-			TileFramer[item.Item1, item.Item2][0] = false;
-			WorldGen.TileFrame(item.Item1, item.Item2, item.Item3);
+			data = TileFramer[item.Item1, item.Item2];
+			WorldGen.TileFrame(item.Item1, item.Item2, data[1]);
+			data[0] = false;
+			data[1] = false;
 
 		}
 		TileQueue = new();
-		for (LinkedListNode<Tuple<int, int, bool>> node = WallQueue.First; node != null; node = node.Next) {
+		for (LinkedListNode<Tuple<int, int>> node = WallQueue.First; node != null; node = node.Next) {
 			item = node.Value;
-			TileFramer[item.Item1, item.Item2][1] = false;
-			Framing.WallFrame(item.Item1, item.Item2, item.Item3);
+			data = TileFramer[item.Item1, item.Item2];
+			Framing.WallFrame(item.Item1, item.Item2, data[3]);
+			data[2] = false;
+			data[3] = false;
 		}
 		WallQueue = new();
 	}

--- a/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
+++ b/patches/tModLoader/Terraria/ModLoader/ConversionHandler.cs
@@ -102,8 +102,8 @@ public sealed class ConversionHandler
 	public const int Break = -2;
 
 	// Would be lovely to have a better way than this.
-	internal static int TileIndex(int index, int type) => (TileLoader.TileCount * index) + type;
-	internal static int WallIndex(int index, int type) => (TileLoader.TileCount * ConversionDatabase.conversions.Count) + (WallLoader.WallCount * index) + type;
+	internal static int TileIndex(int index, int type) => (TileLoader.TileCount + WallLoader.WallCount) * index + type;
+	internal static int WallIndex(int index, int type) => (TileLoader.TileCount + WallLoader.WallCount) * index + TileLoader.TileCount + type;
 
 	internal static void FillData()
 	{
@@ -111,6 +111,8 @@ public sealed class ConversionHandler
 			Array.Clear(data);
 		}
 		data = new Conversion.BlockConversion[(TileLoader.TileCount * ConversionDatabase.conversions.Count) + (TileLoader.TileCount * ConversionDatabase.conversions.Count)];
+		for(int x = 0; x < data.Length; x++) {
+		}
 		foreach (var conv in ConversionDatabase.conversions.Values) {
 			conv.Fill(data);
 		}
@@ -408,7 +410,7 @@ public sealed class ConversionHandler
 		ref byte transformations, ConversionSettings settings,
 		byte wasCalled, byte breakBlock, byte replacedBlock)
 	{
-		if (block != null && value != ConversionRunCodeValues.DontRun) {
+		if (block.From != block.To && value != ConversionRunCodeValues.DontRun) {
 			transformations |= wasCalled;
 
 			int conv = block.To;

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -2501,7 +2501,7 @@
 +					else {
 +						id = BiomeConversionID.Corruption;
 +					}
-+					ConversionHandler.Convert(id, m, n, new(false, false, false));
++					ConversionHandler.Convert(id, m, n, new(true, false, false));
  				}
  			}
  

--- a/patches/tModLoader/Terraria/WorldGen.cs.patch
+++ b/patches/tModLoader/Terraria/WorldGen.cs.patch
@@ -388,7 +388,7 @@
  		remixWorldGen = tempRemixWorldGen;
  		tenthAnniversaryWorldGen = tempTenthAnniversaryWorldGen;
  		drunkWorldGen = false;
-@@ -6030,10 +_,13 @@
+@@ -6030,14 +_,20 @@
  		}
  
  		Main.zenithWorld = everythingWorldGen;
@@ -403,6 +403,13 @@
  		_lastSeed = seed;
  		_generator = new WorldGenerator(seed, GenVars.configuration);
  		_genRand = new UnifiedRandom(seed);
+ 		Main.rand = new UnifiedRandom(seed);
++
++		TileFrameCache.InitializeTileFramer();
++
+ 		GenVars.structures = new StructureMap();
+ 		GenVars.desertHiveHigh = Main.maxTilesY;
+ 		GenVars.desertHiveLow = 0;
 @@ -6097,9 +_,18 @@
  		GenVars.logX = -1;
  		GenVars.logY = -1;


### PR DESCRIPTION
1 - structify BlockConversion, allowing cache abuse
2 - now only calls TileFrame once per tile per frame, reducing TileFrame calls by up to a factor of 9